### PR TITLE
Fix InMemoryFilmRepository concurrency issues

### DIFF
--- a/hentai/src/main/java/eu/solidcraft/film/domain/InMemoryFilmRepository.java
+++ b/hentai/src/main/java/eu/solidcraft/film/domain/InMemoryFilmRepository.java
@@ -10,7 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static java.util.Objects.requireNonNull;
 
 class InMemoryFilmRepository implements FilmRepository {
-    private ConcurrentHashMap<String, Film> map = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Film> map = new ConcurrentHashMap<>();
 
     @Override
     public Film save(Film film) {
@@ -31,7 +31,8 @@ class InMemoryFilmRepository implements FilmRepository {
 
     @Override
     public Page<Film> findAll(Pageable pageable) {
-        return new PageImpl<>(new ArrayList<>(map.values()), pageable, map.size());
+        List<Film> films = new ArrayList<>(map.values());
+        return new PageImpl<>(films, pageable, films.size());
     }
 
 }

--- a/hentai/src/main/java/eu/solidcraft/film/domain/InMemoryFilmRepository.java
+++ b/hentai/src/main/java/eu/solidcraft/film/domain/InMemoryFilmRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Objects.requireNonNull;


### PR DESCRIPTION
For `InMemoryFilmRepository` class to become thread-safe, `map` field is required to be `final` so safe-publication is ensured. Additionaly there was a race condition in `findAll` method, since `map` could change between calls to `values()` and `size()`.